### PR TITLE
feat export menu

### DIFF
--- a/src/components/ActionButtons.tsx
+++ b/src/components/ActionButtons.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import * as Dropdown from "@/components/ui/dropdown-menu";
 import { Eye, Edit2, RotateCcw, Download } from "lucide-react";
 import { ReportButton } from "@/components/ReportButton";
 import type { TimelineEvent } from "@/pages/Index";
@@ -14,6 +15,7 @@ interface ActionButtonsProps {
   // Visualization specific props
   onResetLayout?: () => void;
   onExportPng?: () => void;
+  onExportSvg?: () => void;
 }
 
 export function ActionButtons({
@@ -23,6 +25,7 @@ export function ActionButtons({
   onEditMode,
   onResetLayout,
   onExportPng,
+  onExportSvg,
   isEditMode,
 }: ActionButtonsProps) {
   return (
@@ -43,17 +46,32 @@ export function ActionButtons({
           <ReportButton incident={incident} events={events} />
         </>
       )}
-
+      
       {page === 'visualization' && (
         <>
           <Button variant="outline" onClick={onResetLayout}>
             <RotateCcw className="mr-2 h-4 w-4" />
             Reset Layout
           </Button>
-          <Button variant="outline" onClick={onExportPng}>
-            <Download className="mr-2 h-4 w-4" />
-            Export as PNG
-          </Button>
+          <Dropdown.DropdownMenu>
+            <Dropdown.DropdownMenuTrigger asChild> 
+              <Button variant="outline">
+                <Download className="mr-2 h-4 w-4" />
+                Export
+              </Button>
+            </Dropdown.DropdownMenuTrigger>
+
+            <Dropdown.DropdownMenuPortal>
+				      <Dropdown.DropdownMenuContent align="center">
+                <Dropdown.DropdownMenuItem onClick={onExportPng}>
+                  As PNG
+					      </Dropdown.DropdownMenuItem>
+					      <Dropdown.DropdownMenuItem onClick={onExportSvg} >
+                  As SVG
+					      </Dropdown.DropdownMenuItem>
+              </Dropdown.DropdownMenuContent>
+            </Dropdown.DropdownMenuPortal>    
+          </Dropdown.DropdownMenu>
         </>
       )}
 

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -149,18 +149,18 @@ const Flow: React.FC<VisualizationProps> = ({
     if (reactFlowWrapper.current === null) {
       return;
     }
-
-    const nodesBounds = getRectOfNodes(nodes);
-    const transform = getTransformForBounds(nodesBounds, 1000, 800, 0.5, 2);
     
-    const dataUrl = await toPng(reactFlowWrapper.current, {
-      backgroundColor: '#ffffff',
-      width: 1000,
-      height: 1000,
+    const nodesBounds = getNodesBounds(nodes);
+    const transform = getViewportForBounds(nodesBounds, 1280, 720, 0.5, 2);
+    
+    const dataUrl = await toPng<HTMLElement>(document.querySelector('.react-flow__viewport'), {
+      backgroundColor: '#aaaaaa',
+      width: 1280,
+      height: 720,
       style: {
-        width: '1000px',
-        height: '800px',
-        transform: `translate(${transform[0]}px, ${transform[1]}px) scale(${transform[2]})`,
+        width: '1280px',
+        height: '720px',
+        transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.zoom})`,
       },
     });
 

--- a/src/components/Visualization.tsx
+++ b/src/components/Visualization.tsx
@@ -28,7 +28,7 @@ import type { TimelineEvent } from '@/pages/Index';
 import { calculateLayout } from './visualization/layoutUtils';
 import { cn } from '@/lib/utils';
 import { ActionButtons } from './ActionButtons';
-import { toPng } from 'html-to-image';
+import { toPng, toSvg } from 'html-to-image';
 
 interface VisualizationProps {
   events: TimelineEvent[];
@@ -145,6 +145,22 @@ const Flow: React.FC<VisualizationProps> = ({
     }
   };
 
+  const handleExportSvg = async () => {
+    if (reactFlowWrapper.current === null) {
+      return;
+    }
+    
+    const nodesBounds = getNodesBounds(nodes);
+    const transform = getViewportForBounds(nodesBounds, 1280, 720, 0.5, 2);
+    
+    const dataUrl = await toSvg<HTMLElement>(document.querySelector('.react-flow__viewport'), {});
+
+    const link = document.createElement('a');
+    link.download = 'threat-timeline.svg';
+    link.href = dataUrl;
+    link.click();
+  };
+
   const handleExportPng = async () => {
     if (reactFlowWrapper.current === null) {
       return;
@@ -236,6 +252,7 @@ const Flow: React.FC<VisualizationProps> = ({
           <ActionButtons
             page="visualization"
             onResetLayout={onResetRequest}
+            onExportSvg={handleExportSvg}
             onExportPng={handleExportPng}
             events={events}
           />


### PR DESCRIPTION
Fixes export PNG behavior to create an image of the entire graph rather than a portion of the user's active view. Introduces an export dropdown including the export as PNG and a new export as SVG feature. (working but still a WIP) 